### PR TITLE
Make TCP interfaces compatible.

### DIFF
--- a/arch/x86/include/asm/kvm_host.h
+++ b/arch/x86/include/asm/kvm_host.h
@@ -669,9 +669,8 @@ struct kvm_lpage_info {
 
 #define KVM_DSM_DEBUG
 
-/* TODO: Make TCP interfaces compatible. */
-//#define USE_KTCP_NETWORK
-#define USE_KRDMA_NETWORK
+#define USE_KTCP_NETWORK
+//#define USE_KRDMA_NETWORK
 
 #define IVY_KVM_DSM
 //#define TARDIS_KVM_DSM

--- a/arch/x86/kvm/ktcp.c
+++ b/arch/x86/kvm/ktcp.c
@@ -28,6 +28,7 @@
 #include <linux/slab.h>
 #include <linux/delay.h>
 
+#include <linux/kvm_host.h>
 #include "ktcp.h"
 
 struct ktcp_hdr {
@@ -81,11 +82,11 @@ repeat_send:
 }
 
 int ktcp_send(struct socket *sock, const char *buffer, size_t length,
-		unsigned long flags, extent_t extent)
+		unsigned long flags, const extent_t *extent)
 {
 	struct ktcp_hdr hdr = {
 		.length = length,
-		.extent = extent,
+		.extent = *extent,
 	};
 	int ret;
 	mm_segment_t oldmm;

--- a/arch/x86/kvm/ktcp.h
+++ b/arch/x86/kvm/ktcp.h
@@ -8,10 +8,11 @@
 // How many requests can be buffered in the listening queue
 #define DEFAULT_BACKLOG 16
 
-typedef uint32_t extent_t;
+struct tx_add;
+typedef struct tx_add extent_t;
 
 int ktcp_send(struct socket *sock, const char *buffer, size_t length,
-		unsigned long flags, extent_t extent);
+		unsigned long flags, const extent_t *extent);
 
 int ktcp_receive(struct socket *sock, char *buffer, unsigned long flags,
 		extent_t *extent);


### PR DESCRIPTION
This is a proposed patch to get the TCP working. It simply redefines the "struct tx_add" to "extent_t":
``` 
typedef struct tx_add extent_t;
```